### PR TITLE
Replace envsubst with sed

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,7 @@ suggested repository.  To avoid duplicating ephemeral data (namespace,
 timestamp tag, …), they appear in the `Dockerfile.template` as markers
 (`${NAMESPACE}`, `${TAG}`, …).  The `build.sh` script replaces the
 markers with values while generating a `Dockerfile` from each
-`Dockerfile.template` (using [envsubst][]), and then builds each tag
-with:
+`Dockerfile.template` (using sed), and then builds each tag with:
 
     $ docker build -t $NAMESPACE/$REPO:$TAG $REPO
 
@@ -120,5 +119,4 @@ as you see fit.
 [Gentoo]: http://www.gentoo.org/
 [BusyBox]: http://www.busybox.net/
 [Portage]: http://www.gentoo.org//doc/en/handbook/handbook-x86.xml?part=3
-[envsubst]: http://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html
 [parameter-expansion]: http://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02

--- a/build.sh
+++ b/build.sh
@@ -229,16 +229,11 @@ generate_dockerfile()
     if [ ! -f ${1}/Dockerfile.template ]; then
         die "error: repo ${REPO_PATH}/${1} does not have a Dockerfile.template"
     fi
-    env -i \
-    NAMESPACE="${NAMESPACE}" \
-    TAG="${DATE}" \
-    MAINTAINER="${AUTHOR}" \
-    envsubst '
-    ${NAMESPACE}
-    ${TAG}
-    ${MAINTAINER}
-    ' \
-    < "$1/Dockerfile.template" > "$1/Dockerfile"
+
+    sed \
+        -e 's/${NAMESPACE}/'"${NAMESPACE}"'/' \
+        -e 's/${TAG}/'"${DATE}"'/' \
+        -e 's/${MAINTAINER}/'"${AUTHOR}"'/' "$1/Dockerfile.template" > "$1/Dockerfile"
 }
 
 # Generate package.provided, doc.package.provided and copy req. files from parent image for given REPO.


### PR DESCRIPTION
This makes the build script more portable since envsubst is part of the gettext suite. This fixes #13.
