### PR TITLE
Add headless-awt USE-flag to jdk-icedtea

### DIFF
--- a/dock/kubler/images/jdk-icedtea/build.sh
+++ b/dock/kubler/images/jdk-icedtea/build.sh
@@ -8,7 +8,7 @@ _packages="dev-java/icedtea-bin"
 #
 configure_rootfs_build()
 {
-    update_use 'dev-java/icedtea-bin' '-webstart'
+    update_use 'dev-java/icedtea-bin' '-webstart' '+headless-awt'
     # skip python and nss
     provide_package dev-lang/python
     provide_package dev-libs/nss


### PR DESCRIPTION
Prevents installing a bunch of X11 packages.