### PR TITLE
Relative paths in --working-dir option

### DIFF
--- a/kubler.sh
+++ b/kubler.sh
@@ -135,7 +135,8 @@ function main() {
     [[ -z "${_arg_command}" && "${_arg_help}" == 'on' ]] && { show_help; exit 0; }
 
     # KUBLER_WORKING_DIR overrides --working-dir, else use current working directory
-    working_dir="${KUBLER_WORKING_DIR:-${_arg_working_dir}}"
+    get_absolute_path "${KUBLER_WORKING_DIR:-${_arg_working_dir}}"
+    working_dir="${__get_absolute_path}"
     [[ -z "${working_dir}" ]] && working_dir="${PWD}"
     detect_namespace "${working_dir}"
 


### PR DESCRIPTION
Namespace creation hangs when a relative path was passed to the --working-dir option.

Steps to reproduce
```
git clone https://github.com/edannenberg/kubler.git
mkdir myproject
cd kubler
git checkout a03e77bbd40be173ed3b2f73bdaca1d7ff39d737
./kubler.sh --working-dir=../myproject new namespace test
```

This PR fixes the issue.