### PR TITLE
Reduce access to global state in functions

### DIFF
--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -3,13 +3,15 @@
 # All rights reserved.
 
 # Arguments:
-# 1: namespace_name
+# 1: namespaces_base_dir
+# 2: namespace_name
 function add_namespace() {
-    local ns_name ns_dir def_type def_name def_mail def_engine def_mail def_image_tag regex
-    ns_name="$1"
-    ns_dir="${_NAMESPACE_DIR}/${ns_name}"
+    local ns_base_dir ns_name ns_dir def_type def_name def_mail def_engine def_mail def_image_tag regex
+    ns_base_dir="$1"
+    ns_name="$2"
+    ns_dir="${ns_base_dir}/${ns_name}"
     [[ -d "${ns_dir}" ]] && die "${ns_dir} already exists, aborting."
-    [[ "${_NAMESPACE_TYPE}" == 'single' ]] && die "${_NAMESPACE_DIR} namespace is of type single, aborting."
+    [[ "${_NAMESPACE_TYPE}" == 'single' ]] && die "${ns_base_dir} namespace is of type single, aborting."
 
     def_type='multi'
     def_name='John Doe'
@@ -188,7 +190,7 @@ function main() {
 
     case "${_arg_template_type}" in
         namespace)
-            add_namespace "${target_id}"
+            add_namespace "${_NAMESPACE_DIR}" "${target_id}"
             ;;
         image)
             add_image

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -109,12 +109,14 @@ To manage the new namespace with GIT you may want to run:
 
 # Arguments
 # 1: Namespace
+# 2: Image or builder name
 function get_ns_conf() {
     __get_ns_conf=
-    local ns_name ns_conf_file
+    local ns_name image_name ns_conf_file
     ns_name="$1"
+    image_name="$2"
 
-    if [[ -z "${ns_name}" || -z "${_tmpl_image_name}" ]] && [[ "${_NAMESPACE_TYPE}" != 'single' ]]; then
+    if [[ -z "${ns_name}" || -z "${image_name}" ]] && [[ "${_NAMESPACE_TYPE}" != 'single' ]]; then
         # shellcheck disable=SC2154
         die "${_arg_name} should have format <namespace>/<image_name>"
     fi
@@ -135,7 +137,7 @@ function add_image() {
     ns_name="$1"
     image_name="$2"
 
-    get_ns_conf "${ns_name}"
+    get_ns_conf "${ns_name}" "${image_name}"
     # shellcheck source=dock/kubler/kubler.conf
     source "${__get_ns_conf}"
 
@@ -166,7 +168,7 @@ function add_builder() {
     ns_name="$1"
     builder_name="$2"
 
-    get_ns_conf "${ns_name}"
+    get_ns_conf "${ns_name}" "${builder_name}"
     # shellcheck source=dock/kubler/kubler.conf
     source "${__get_ns_conf}"
 

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -133,11 +133,13 @@ You can create a new namespace by running: ${_KUBLER_BIN} new namespace ${ns_nam
 
 # Arguments
 # 1: Namespace
-# 2: Image name
+# 2: Build engine used by the namespace
+# 3: Image name
 function add_image() {
-    local ns_name image_name image_base_path image_path
+    local ns_name build_engine image_name image_base_path image_path
     ns_name="$1"
-    image_name="$2"
+    build_engine="$2"
+    image_name="$3"
 
     msg '\n<enter> to accept default value\n'
 
@@ -151,7 +153,7 @@ function add_image() {
     [ -d "${image_path}" ] && die "${image_path} already exists, aborting!"
     [ ! -d "${image_base_path}" ] && mkdir -p "${image_base_path}"
 
-    cp -r "${_LIB_DIR}/template/${BUILD_ENGINE}/image" "${image_path}" || die
+    cp -r "${_LIB_DIR}/template/${build_engine}/image" "${image_path}" || die
 
     _template_target="${image_path}"
     _post_msg="Successfully created ${_arg_name} image at ${image_path}\\n"
@@ -210,7 +212,7 @@ function main() {
             get_ns_conf "${_tmpl_namespace}" "${_tmpl_image_name}"
             # shellcheck source=dock/kubler/kubler.conf
             source "${__get_ns_conf}"
-            add_image "${_tmpl_namespace}" "${_tmpl_image_name}"
+            add_image "${_tmpl_namespace}" "${BUILD_ENGINE}" "${_tmpl_image_name}"
             ;;
         builder)
             add_builder "${_tmpl_namespace}" "${_tmpl_image_name}"

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -127,10 +127,13 @@ You can create a new namespace by running: ${_KUBLER_BIN} new namespace ${ns_nam
     __get_ns_conf="${ns_conf_file}"
 }
 
+# Arguments
+# 1: Namespace
 function add_image() {
-    local image_base_path image_path
+    local ns_name image_base_path image_path
+    ns_name="$1"
 
-    get_ns_conf "${_tmpl_namespace}"
+    get_ns_conf "${ns_name}"
     # shellcheck source=dock/kubler/kubler.conf
     source "${__get_ns_conf}"
 
@@ -140,7 +143,7 @@ function add_image() {
     read -r -p 'Parent Image (scratch): ' _tmpl_image_parent
     [ -z "${_tmpl_image_parent}" ] && _tmpl_image_parent='scratch'
 
-    image_base_path="${_NAMESPACE_DIR}/${_tmpl_namespace}/images"
+    image_base_path="${_NAMESPACE_DIR}/${ns_name}/images"
     image_path="${image_base_path}/${_tmpl_image_name}"
 
     [ -d "${image_path}" ] && die "${image_path} already exists, aborting!"
@@ -200,7 +203,7 @@ function main() {
             add_namespace "${_NAMESPACE_DIR}" "${target_id}"
             ;;
         image)
-            add_image
+            add_image "${_tmpl_namespace}"
             ;;
         builder)
             add_builder "${_tmpl_namespace}"

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -162,11 +162,13 @@ function add_image() {
 
 # Arguments
 # 1: Namespace
-# 2: Builder name
+# 2: Build engine used by the namespace
+# 3: Builder name
 function add_builder() {
-    local ns_name builder_name builder_base_path builder_path
+    local ns_name build_engine builder_name builder_base_path builder_path
     ns_name="$1"
-    builder_name="$2"
+    build_engine="$2"
+    builder_name="$3"
 
     msg '\n<enter> to accept default value\n'
 
@@ -184,7 +186,7 @@ function add_builder() {
     [ -d "${builder_path}" ] && die "${builder_path} already exists, aborting!"
     [ ! -d "${builder_base_path}" ] && mkdir -p "${builder_base_path}"
 
-    cp -r "${_LIB_DIR}/template/${BUILD_ENGINE}/builder" "${builder_path}" || die
+    cp -r "${_LIB_DIR}/template/${build_engine}/builder" "${builder_path}" || die
 
     _template_target="${builder_path}"
     _post_msg="Successfully created ${_arg_name} builder at ${builder_path}\\n"
@@ -211,10 +213,10 @@ function main() {
             add_image "${_tmpl_namespace}" "${BUILD_ENGINE}" "${_tmpl_image_name}"
             ;;
         builder)
-            get_ns_conf "${ns_name}" "${builder_name}"
+            get_ns_conf "${_tmpl_namespace}" "${_tmpl_image_name}"
             # shellcheck source=dock/kubler/kubler.conf
             source "${__get_ns_conf}"
-            add_builder "${_tmpl_namespace}" "${_tmpl_image_name}"
+            add_builder "${_tmpl_namespace}" "${BUILD_ENGINE}" "${_tmpl_image_name}"
             ;;
         *)
             show_help

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -164,7 +164,9 @@ function add_image() {
 # 1: Namespace
 # 2: Build engine used by the namespace
 # 3: Builder name
+# Return value: Type of the created builder
 function add_builder() {
+    __add_builder=
     local ns_name build_engine builder_name builder_base_path builder_path
     ns_name="$1"
     build_engine="$2"
@@ -190,6 +192,7 @@ function add_builder() {
 
     _template_target="${builder_path}"
     _post_msg="Successfully created ${_arg_name} builder at ${builder_path}\\n"
+    __add_builder="${_tmpl_builder_type}"
 }
 
 function main() {
@@ -231,7 +234,7 @@ function main() {
         sed_args+=('-e' "s|\${${tmpl_var}}|${!tmpl_var}|g")
     done
     if [[ "${_arg_template_type}" == "builder" ]]; then
-        if [[ "${_tmpl_builder_type}" == "stage3" ]]; then
+        if [[ "${__add_builder}" == "stage3" ]]; then
             sed_args+=('-e' "s|^BUILDER|#BUILDER|g")
         else
             sed_args+=('-e' "s|^STAGE3|#STAGE3|g")

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -172,15 +172,18 @@ function add_builder() {
     build_engine="$2"
     builder_name="$3"
 
+    local builder_settings=([type]='stage3')
+
     msg '\n<enter> to accept default value\n'
 
     msg 'Extend an existing builder? Fully qualified image id (i.e. kubler/bob) if yes or else stage3'
-    read -r -p 'Parent Image (stage3): ' _tmpl_builder_type
-    [ -z "${_tmpl_builder_type}" ] && _tmpl_builder_type='stage3'
+    local builder_type
+    read -r -p "Parent Image (${builder_settings[type]}): " builder_type
+    [ -n "${builder_type}" ] && builder_settings[type]="${builder_type}"
 
-    _tmpl_builder="${_tmpl_builder_type}"
+    _tmpl_builder="${builder_settings[type]}"
     # shellcheck disable=SC2016,SC2034
-    [[ "${_tmpl_builder_type}" == "stage3" ]] && _tmpl_builder='\${_current_namespace}/bob'
+    [[ "${builder_settings[type]}" == "stage3" ]] && _tmpl_builder='\${_current_namespace}/bob'
 
     builder_base_path="${_NAMESPACE_DIR}/${ns_name}/builder"
     builder_path="${builder_base_path}/${builder_name}"
@@ -192,7 +195,7 @@ function add_builder() {
 
     _template_target="${builder_path}"
     _post_msg="Successfully created ${_arg_name} builder at ${builder_path}\\n"
-    __add_builder="${_tmpl_builder_type}"
+    __add_builder="${builder_settings[type]}"
 }
 
 function main() {

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -3,15 +3,17 @@
 # All rights reserved.
 
 # Arguments:
-# 1: namespaces_base_dir
-# 2: namespace_name
+# 1: Namespace base directory
+# 2: Namespace name
+# 3: Namespace type
 function add_namespace() {
-    local ns_base_dir ns_name ns_dir def_type def_name def_mail def_engine def_mail def_image_tag regex
+    local ns_base_dir ns_name ns_type ns_dir def_type def_name def_mail def_engine def_mail def_image_tag regex
     ns_base_dir="$1"
     ns_name="$2"
+    ns_type="$3"
     ns_dir="${ns_base_dir}/${ns_name}"
     [[ -d "${ns_dir}" ]] && die "${ns_dir} already exists, aborting."
-    [[ "${_NAMESPACE_TYPE}" == 'single' ]] && die "${ns_base_dir} namespace is of type single, aborting."
+    [[ "${ns_type}" == 'single' ]] && die "${ns_base_dir} namespace is of type single, aborting."
 
     def_type='multi'
     def_name='John Doe'
@@ -27,7 +29,7 @@ function add_namespace() {
 
     msg "New namespace location:  ${ns_dir}"
 
-    if [[ "${_NAMESPACE_TYPE}" == 'none' ]]; then
+    if [[ "${ns_type}" == 'none' ]]; then
         msg "--> What type of namespace? To allow multiple namespaces choose 'multi', else 'single'.
     The only upshot of 'single' mode is saving one directory level, the downside is loss of cross-namespace access."
         read -r -p "Type (${def_type}): " _tmpl_ns_type
@@ -38,7 +40,7 @@ function add_namespace() {
         read -r -p "Image Tag (${def_image_tag}): " _tmpl_image_tag
         [[ -z "${_tmpl_image_tag}" ]] && _tmpl_image_tag="${def_image_tag}"
     else
-        msg "Namespace Type:          ${_NAMESPACE_TYPE}"
+        msg "Namespace Type:          ${ns_type}"
     fi
 
     msg '\n--> Who maintains the new namespace?'
@@ -59,7 +61,7 @@ function add_namespace() {
     local real_ns_dir default_conf
     real_ns_dir="${ns_dir}"
 
-    if [[ "${_NAMESPACE_TYPE}" == 'none' && "${_tmpl_ns_type}" == 'multi' ]]; then
+    if [[ "${ns_type}" == 'none' && "${_tmpl_ns_type}" == 'multi' ]]; then
         real_ns_dir="${ns_dir}/${ns_name}"
         mkdir "${ns_dir}"
         _sub_tmpl_target="${real_ns_dir}"
@@ -68,7 +70,7 @@ function add_namespace() {
     cp -r "${_LIB_DIR}/template/${_tmpl_engine}/namespace" "${real_ns_dir}" || die
 
 
-    if [[ "${_NAMESPACE_TYPE}" == 'none' ]]; then
+    if [[ "${ns_type}" == 'none' ]]; then
         if [[ "${_tmpl_ns_type}" == 'multi' ]]; then
             # link kubler namespace per default for multi namespaces
             ln -s "${_KUBLER_NAMESPACE_DIR}/kubler" "${ns_dir}"/
@@ -94,7 +96,7 @@ To manage the new namespace with GIT you may want to run:
 
     git init ${real_ns_dir}"
 
-    if [[ "${_NAMESPACE_TYPE}" == 'none' && "${_tmpl_ns_type}" == 'single' ]]; then
+    if [[ "${ns_type}" == 'none' && "${_tmpl_ns_type}" == 'single' ]]; then
         _post_msg="${_post_msg}\\n\\n!!! As this is a new single namespace you need to create a new builder first:\\n
     cd ${ns_dir}/
     ${_KUBLER_BIN} new builder bob"
@@ -206,7 +208,7 @@ function main() {
 
     case "${_arg_template_type}" in
         namespace)
-            add_namespace "${_NAMESPACE_DIR}" "${target_id}"
+            add_namespace "${_NAMESPACE_DIR}" "${target_id}" "${_NAMESPACE_TYPE}"
             ;;
         image)
             add_image "${_tmpl_namespace}" "${_tmpl_image_name}"

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -139,10 +139,6 @@ function add_image() {
     ns_name="$1"
     image_name="$2"
 
-    get_ns_conf "${ns_name}" "${image_name}"
-    # shellcheck source=dock/kubler/kubler.conf
-    source "${__get_ns_conf}"
-
     msg '\n<enter> to accept default value\n'
 
     msg 'Extend an existing image? Fully qualified image id (i.e. kubler/busybox) if yes or scratch'
@@ -211,6 +207,9 @@ function main() {
             add_namespace "${_NAMESPACE_DIR}" "${target_id}" "${_NAMESPACE_TYPE}"
             ;;
         image)
+            get_ns_conf "${_tmpl_namespace}" "${_tmpl_image_name}"
+            # shellcheck source=dock/kubler/kubler.conf
+            source "${__get_ns_conf}"
             add_image "${_tmpl_namespace}" "${_tmpl_image_name}"
             ;;
         builder)

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -156,7 +156,7 @@ function add_image() {
     cp -r "${_LIB_DIR}/template/${build_engine}/image" "${image_path}" || die
 
     _template_target="${image_path}"
-    _post_msg="Successfully created ${_arg_name} image at ${image_path}\\n"
+    _post_msg="Successfully created image \"${image_name}\" in namespace \"${ns_name}\" at ${image_path}\\n"
 }
 
 

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -129,9 +129,11 @@ You can create a new namespace by running: ${_KUBLER_BIN} new namespace ${ns_nam
 
 # Arguments
 # 1: Namespace
+# 2: Image name
 function add_image() {
-    local ns_name image_base_path image_path
+    local ns_name image_name image_base_path image_path
     ns_name="$1"
+    image_name="$2"
 
     get_ns_conf "${ns_name}"
     # shellcheck source=dock/kubler/kubler.conf
@@ -144,7 +146,7 @@ function add_image() {
     [ -z "${_tmpl_image_parent}" ] && _tmpl_image_parent='scratch'
 
     image_base_path="${_NAMESPACE_DIR}/${ns_name}/images"
-    image_path="${image_base_path}/${_tmpl_image_name}"
+    image_path="${image_base_path}/${image_name}"
 
     [ -d "${image_path}" ] && die "${image_path} already exists, aborting!"
     [ ! -d "${image_base_path}" ] && mkdir -p "${image_base_path}"
@@ -203,7 +205,7 @@ function main() {
             add_namespace "${_NAMESPACE_DIR}" "${target_id}"
             ;;
         image)
-            add_image "${_tmpl_namespace}"
+            add_image "${_tmpl_namespace}" "${_tmpl_image_name}"
             ;;
         builder)
             add_builder "${_tmpl_namespace}"

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -168,10 +168,6 @@ function add_builder() {
     ns_name="$1"
     builder_name="$2"
 
-    get_ns_conf "${ns_name}" "${builder_name}"
-    # shellcheck source=dock/kubler/kubler.conf
-    source "${__get_ns_conf}"
-
     msg '\n<enter> to accept default value\n'
 
     msg 'Extend an existing builder? Fully qualified image id (i.e. kubler/bob) if yes or else stage3'
@@ -215,6 +211,9 @@ function main() {
             add_image "${_tmpl_namespace}" "${BUILD_ENGINE}" "${_tmpl_image_name}"
             ;;
         builder)
+            get_ns_conf "${ns_name}" "${builder_name}"
+            # shellcheck source=dock/kubler/kubler.conf
+            source "${__get_ns_conf}"
             add_builder "${_tmpl_namespace}" "${_tmpl_image_name}"
             ;;
         *)

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -127,7 +127,7 @@ You can create a new namespace by running: ${_KUBLER_BIN} new namespace ${_tmpl_
 function add_image() {
     local image_base_path image_path
 
-    get_ns_conf "${_IMAGE_PATH}"
+    get_ns_conf
     # shellcheck source=dock/kubler/kubler.conf
     source "${__get_ns_conf}"
 
@@ -152,7 +152,7 @@ function add_image() {
 function add_builder() {
     local builder_base_path builder_path
 
-    get_ns_conf "${_BUILDER_PATH}"
+    get_ns_conf
     # shellcheck source=dock/kubler/kubler.conf
     source "${__get_ns_conf}"
 

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -190,7 +190,7 @@ function add_builder() {
 
 function main() {
     local sed_args tmpl_var tmpl_file
-    target_id="${_arg_name}"
+    local target_id="${_arg_name}"
     _sub_tmpl_target=
     # shellcheck disable=SC2154
     [[ "${target_id}" != *"/"* && "${_arg_template_type}" != 'namespace' && -n "${_NAMESPACE_DEFAULT}" ]] \

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -152,10 +152,14 @@ function add_image() {
     _post_msg="Successfully created ${_arg_name} image at ${image_path}\\n"
 }
 
-function add_builder() {
-    local builder_base_path builder_path
 
-    get_ns_conf "${_tmpl_namespace}"
+# Arguments
+# 1: Namespace
+function add_builder() {
+    local ns_name builder_base_path builder_path
+    ns_name="$1"
+
+    get_ns_conf "${ns_name}"
     # shellcheck source=dock/kubler/kubler.conf
     source "${__get_ns_conf}"
 
@@ -169,7 +173,7 @@ function add_builder() {
     # shellcheck disable=SC2016,SC2034
     [[ "${_tmpl_builder_type}" == "stage3" ]] && _tmpl_builder='\${_current_namespace}/bob'
 
-    builder_base_path="${_NAMESPACE_DIR}/${_tmpl_namespace}/builder"
+    builder_base_path="${_NAMESPACE_DIR}/${ns_name}/builder"
     builder_path="${builder_base_path}/${_tmpl_image_name}"
 
     [ -d "${builder_path}" ] && die "${builder_path} already exists, aborting!"
@@ -199,7 +203,7 @@ function main() {
             add_image
             ;;
         builder)
-            add_builder
+            add_builder "${_tmpl_namespace}"
             ;;
         *)
             show_help

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -160,9 +160,11 @@ function add_image() {
 
 # Arguments
 # 1: Namespace
+# 2: Builder name
 function add_builder() {
-    local ns_name builder_base_path builder_path
+    local ns_name builder_name builder_base_path builder_path
     ns_name="$1"
+    builder_name="$2"
 
     get_ns_conf "${ns_name}"
     # shellcheck source=dock/kubler/kubler.conf
@@ -179,7 +181,7 @@ function add_builder() {
     [[ "${_tmpl_builder_type}" == "stage3" ]] && _tmpl_builder='\${_current_namespace}/bob'
 
     builder_base_path="${_NAMESPACE_DIR}/${ns_name}/builder"
-    builder_path="${builder_base_path}/${_tmpl_image_name}"
+    builder_path="${builder_base_path}/${builder_name}"
 
     [ -d "${builder_path}" ] && die "${builder_path} already exists, aborting!"
     [ ! -d "${builder_base_path}" ] && mkdir -p "${builder_base_path}"
@@ -208,7 +210,7 @@ function main() {
             add_image "${_tmpl_namespace}" "${_tmpl_image_name}"
             ;;
         builder)
-            add_builder "${_tmpl_namespace}"
+            add_builder "${_tmpl_namespace}" "${_tmpl_image_name}"
             ;;
         *)
             show_help

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -107,19 +107,22 @@ To manage the new namespace with GIT you may want to run:
 "
 }
 
+# Arguments
+# 1: Namespace
 function get_ns_conf() {
     __get_ns_conf=
-    local ns_conf_file
+    local ns_name ns_conf_file
+    ns_name="$1"
 
-    if [[ -z "${_tmpl_namespace}" || -z "${_tmpl_image_name}" ]] && [[ "${_NAMESPACE_TYPE}" != 'single' ]]; then
+    if [[ -z "${ns_name}" || -z "${_tmpl_image_name}" ]] && [[ "${_NAMESPACE_TYPE}" != 'single' ]]; then
         # shellcheck disable=SC2154
         die "${_arg_name} should have format <namespace>/<image_name>"
     fi
 
-    ns_conf_file="${_NAMESPACE_DIR}/${_tmpl_namespace}/${_KUBLER_CONF}"
+    ns_conf_file="${_NAMESPACE_DIR}/${ns_name}/${_KUBLER_CONF}"
     [ -f "${ns_conf_file}" ] || die "Couldn't read ${ns_conf_file}
 
-You can create a new namespace by running: ${_KUBLER_BIN} new namespace ${_tmpl_namespace}
+You can create a new namespace by running: ${_KUBLER_BIN} new namespace ${ns_name}
 "
     __get_ns_conf="${ns_conf_file}"
 }
@@ -127,7 +130,7 @@ You can create a new namespace by running: ${_KUBLER_BIN} new namespace ${_tmpl_
 function add_image() {
     local image_base_path image_path
 
-    get_ns_conf
+    get_ns_conf "${_tmpl_namespace}"
     # shellcheck source=dock/kubler/kubler.conf
     source "${__get_ns_conf}"
 
@@ -152,7 +155,7 @@ function add_image() {
 function add_builder() {
     local builder_base_path builder_path
 
-    get_ns_conf
+    get_ns_conf "${_tmpl_namespace}"
     # shellcheck source=dock/kubler/kubler.conf
     source "${__get_ns_conf}"
 


### PR DESCRIPTION
This PR substitutes access to constants and global state with function parameters as suggested in #58.
It only touches `lib/new.sh` and there should be no functional changes.
The refactoring is not complete, but since I probably cannot continue to work on this anytime soon, I'd rather file a PR with what I have.