### PR TITLE
Update create image instructions after creating a namespace

### DIFF
--- a/kubler.sh
+++ b/kubler.sh
@@ -141,6 +141,7 @@ function main() {
     detect_namespace "${working_dir}"
     
     if [[ -n "${_arg_working_dir}" ]]; then
+        # shellcheck disable=SC2034
         readonly _KUBLER_BIN_HINT=" --working-dir=${working_dir}"
     fi
 

--- a/kubler.sh
+++ b/kubler.sh
@@ -141,7 +141,7 @@ function main() {
     detect_namespace "${working_dir}"
     
     if [[ -n "${_arg_working_dir}" ]]; then
-        _KUBLER_BIN_HINT=" --working-dir=${working_dir}"
+        readonly _KUBLER_BIN_HINT=" --working-dir=${working_dir}"
     fi
 
     # valid command?

--- a/kubler.sh
+++ b/kubler.sh
@@ -139,6 +139,10 @@ function main() {
     working_dir="${__get_absolute_path}"
     [[ -z "${working_dir}" ]] && working_dir="${PWD}"
     detect_namespace "${working_dir}"
+    
+    if [[ -n "${_arg_working_dir}" ]]; then
+        _KUBLER_BIN_HINT=" --working-dir=${working_dir}"
+    fi
 
     # valid command?
     cmd_script="${_LIB_DIR}/cmd/${_arg_command}.sh"

--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -141,14 +141,12 @@ To manage the new namespace with GIT you may want to run:
 
     if [[ "${_NAMESPACE_TYPE}" == 'none' && "${ns_type}" == 'single' ]]; then
         msg "\\n\\n!!! As this is a new single namespace you need to create a new builder first:\\n
-    cd ${ns_dir}/
-    ${_KUBLER_BIN} new builder bob"
+    ${_KUBLER_BIN}${_KUBLER_BIN_HINT} new builder ${ns_name}/bob"
     fi
 
     msg "\\n\\nTo create images in the new namespace run:
 
-    cd ${ns_dir}/
-    ${_KUBLER_BIN} new image ${ns_name}/<image_name>
+    ${_KUBLER_BIN}${_KUBLER_BIN_HINT} new image ${ns_name}/<image_name>
 "
 }
 


### PR DESCRIPTION
After creating a new namespace, kubler gives instructions how to create a new image. Currently, kubler suggests to cd into the namespace directory and call ``./kubler.sh`` from there. However, this will not work, unless you added kubler to ``$PATH``.

This PR updates the command for creating a new image that is shown after creating a new namespace.
* The command uses ``--working-dir`` if the namespace is not local
* The command does not use the ``--working-dir`` option if a local namespace was created