### PR TITLE
Verify newly created namesapce does is all lowercase

### DIFF
--- a/lib/cmd/new.sh
+++ b/lib/cmd/new.sh
@@ -281,6 +281,9 @@ function main() {
     target_namespace="${target_id%%/*}"
     target_image_name="${target_id##*/}"
 
+    [[ "${target_id}" =~ [A-Z] ]] \
+            && die "Invalid target name: '${target_id}'. Docker requires names to be lowercase"
+
     if [[ "${_arg_template_type}" != 'namespace' ]]; then
         [[ "${target_id}" != *"/"* ]] && die "\"${target_id}\" should have format <namespace>/<image_name>"
         [[ "${_NAMESPACE_TYPE}" == 'none' ]] \


### PR DESCRIPTION
Docker requires repository name to be lowercase.

If user is allowed to create namespace with upper case letters, the problem will be encountered later on during build stage with error:

>      ./kubler.sh new namespace Testing
>      ...
>      ./kubler.sh new image Testing/base
>      ...
>      ./kubler.sh build Testing/base
>      ...
>      commit Testing-base-22103-20293 as Testing/bob-base:20180227
>      invalid reference format: repository name must be lowercase
>      fatal: failed to commit Testing/bob-base:20180227
