### PR TITLE
Fixed error when pushing to a specified repository.

### DIFF
--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -797,11 +797,11 @@ function push_image() {
     repository_url="$2"
     push_id="${image_id}"
     if [[ -n "${repository_url}" ]]; then
-        docker_image_id="$("${DOCKER}" images "${image_id}:${image_tag}" --format '{{.ID}}')"
+        docker_image_id="$("${DOCKER}" images "${image_id}:${IMAGE_TAG}" --format '{{.ID}}')"
         # shellcheck disable=SC2181
-        [[ $? -ne 0 ]] && die "Couldn't determine image id for ${image_id}:${image_tag}: ${docker_image_id}"
+        [[ $? -ne 0 ]] && die "Couldn't determine image id for ${image_id}:${IMAGE_TAG}: ${docker_image_id}"
         push_id="${repository_url}/${image_id}"
-        _status_msg="${DOCKER}" tag "${docker_image_id}" "${push_id}"
+        _status_msg="${DOCKER} tag ${docker_image_id} ${push_id}"
         pwrap "${DOCKER}" tag "${docker_image_id}" "${push_id}" || die
     fi
     add_status_value "${push_id}"


### PR DESCRIPTION
When pushing to a specified repository the following error is observed:

$ kubler push hacking -r docker:5000
»»»»»[auth]» using docker:5000
/usr/share/kubler/engine/docker.sh: line 804: tag: command not found
»»»»»[auth]» this could be your msg
Error parsing reference: "" is not a valid repository/tag: invalid reference format

This pull request should resolve this issue.