### PR TITLE
Build timestamp

### DIFF
--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -173,25 +173,24 @@ function build_image() {
     image_exists_or_rm "${image_id}" "${image_type}"
     exit_sig=$?
     if [[ -z "${missing_builder}" && ${exit_sig} -eq 0 ]]; then
-    	
         if [[ ! -f "${image_path}/${_BUILD_TEST_FAILED_FILE}" && \
               ! -f "${image_path}/${_HEALTHCHECK_FAILED_FILE}" ]]
         then
-        	local image_timestamp parent_timestamp
-        	
-	    	get_image_label "${image_id}" "${IMAGE_TAG}" "kubler.build.timestamp"
-	    	image_timestamp="${__get_image_label}"
-	    	get_image_label "${IMAGE_PARENT}" "${IMAGE_TAG}" "kubler.build.timestamp"
-	    	parent_timestamp="${__get_image_label}"
-	    	
-        	if [[ -z "${parent_timestamp}" || \
-        		  "${parent_timestamp}" -lt "${image_timestamp}" ]]
-			then
-				msg_ok "skipped, already built."
-	            return 0
-           	else
-           		msg_ok "parent more recent than image, rebuilding."
-        	fi
+            local image_timestamp parent_timestamp
+            
+            get_image_label "${image_id}" "${IMAGE_TAG}" "kubler.build.timestamp"
+            image_timestamp="${__get_image_label}"
+            get_image_label "${IMAGE_PARENT}" "${IMAGE_TAG}" "kubler.build.timestamp"
+            parent_timestamp="${__get_image_label}"
+            
+            if [[ -z "${parent_timestamp}" || \
+                  "${parent_timestamp}" -lt "${image_timestamp}" ]]
+            then
+                msg_ok "skipped, already built."
+                return 0
+            else
+                msg_ok "parent more recent than image, rebuilding."
+            fi
         fi
     fi
 
@@ -493,16 +492,16 @@ function get_image_size() {
 # 2: image_tag (a.k.a. version)
 # 3: label_name (i.e. kubler.build.timestamp)
 function get_image_label() {
-	__get_image_label=
-	local image_id image_tag image_label label_value
+    __get_image_label=
+    local image_id image_tag image_label label_value
     image_id="$1"
     image_tag="$2"
     label_name="$3"
     if [[ "${image_id}" != "scratch" ]]; then
-	    image_label=$(docker inspect --format='{{index .Config.Labels "'${label_name}'"}}' ${image_id}:${image_tag})
-	    # shellcheck disable=SC2034
-	    __get_image_label="${image_label}"
-	fi
+        image_label=$(docker inspect --format='{{index .Config.Labels "'${label_name}'"}}' ${image_id}:${image_tag})
+        # shellcheck disable=SC2034
+        __get_image_label="${image_label}"
+    fi
 }
 
 # Start a container from given image_id.

--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -173,11 +173,25 @@ function build_image() {
     image_exists_or_rm "${image_id}" "${image_type}"
     exit_sig=$?
     if [[ -z "${missing_builder}" && ${exit_sig} -eq 0 ]]; then
+    	
         if [[ ! -f "${image_path}/${_BUILD_TEST_FAILED_FILE}" && \
               ! -f "${image_path}/${_HEALTHCHECK_FAILED_FILE}" ]]
         then
-            msg_ok "skipped, already built."
-            return 0
+        	local image_timestamp parent_timestamp
+        	
+	    	get_image_label "${image_id}" "${IMAGE_TAG}" "kubler.build.timestamp"
+	    	image_timestamp="${__get_image_label}"
+	    	get_image_label "${IMAGE_PARENT}" "${IMAGE_TAG}" "kubler.build.timestamp"
+	    	parent_timestamp="${__get_image_label}"
+	    	
+        	if [[ -z "${parent_timestamp}" || \
+        		  "${parent_timestamp}" -lt "${image_timestamp}" ]]
+			then
+				msg_ok "skipped, already built."
+	            return 0
+           	else
+           		msg_ok "parent more recent than image, rebuilding."
+        	fi
         fi
     fi
 
@@ -470,6 +484,25 @@ function get_image_size() {
     [[ $? -ne 0 ]] && die "Couldn't determine image size for ${image_id}:${image_tag}: ${image_size}"
     # shellcheck disable=SC2034
     __get_image_size="${image_size}"
+}
+
+# Sets __get_image_label for a given image_id, image_tag and label_name
+#
+# Arguments:
+# 1: image_id (i.e. kubler/busybox)
+# 2: image_tag (a.k.a. version)
+# 3: label_name (i.e. kubler.build.timestamp)
+function get_image_label() {
+	__get_image_label=
+	local image_id image_tag image_label label_value
+    image_id="$1"
+    image_tag="$2"
+    label_name="$3"
+    if [[ "${image_id}" != "scratch" ]]; then
+	    image_label=$(docker inspect --format='{{index .Config.Labels "'${label_name}'"}}' ${image_id}:${image_tag})
+	    # shellcheck disable=SC2034
+	    __get_image_label="${image_label}"
+	fi
 }
 
 # Start a container from given image_id.

--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -190,6 +190,7 @@ function build_image() {
                 return 0
             else
                 msg_ok "parent more recent than image, rebuilding."
+                skip_rootfs='false'
             fi
         fi
     fi

--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -498,7 +498,7 @@ function get_image_label() {
     image_tag="$2"
     label_name="$3"
     if [[ "${image_id}" != "scratch" ]]; then
-        image_label="$(${DOCKER} inspect --format='{{index .Config.Labels "'"${label_name}"'"}}' ${image_id}:${image_tag})"
+        image_label="$(${DOCKER} inspect --format='{{index .Config.Labels "'"${label_name}"'"}}' "${image_id}":"${image_tag}")"
         # shellcheck disable=SC2034
         __get_image_label="${image_label}"
     fi

--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -498,7 +498,7 @@ function get_image_label() {
     image_tag="$2"
     label_name="$3"
     if [[ "${image_id}" != "scratch" ]]; then
-        image_label=$(docker inspect --format='{{index .Config.Labels "'${label_name}'"}}' ${image_id}:${image_tag})
+        image_label="$(${DOCKER} inspect --format='{{index .Config.Labels "'${label_name}'"}}' ${image_id}:${image_tag})"
         # shellcheck disable=SC2034
         __get_image_label="${image_label}"
     fi

--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -493,12 +493,12 @@ function get_image_size() {
 # 3: label_name (i.e. kubler.build.timestamp)
 function get_image_label() {
     __get_image_label=
-    local image_id image_tag image_label label_value
+    local image_id image_tag image_label
     image_id="$1"
     image_tag="$2"
     label_name="$3"
     if [[ "${image_id}" != "scratch" ]]; then
-        image_label="$(${DOCKER} inspect --format='{{index .Config.Labels "'${label_name}'"}}' ${image_id}:${image_tag})"
+        image_label="$(${DOCKER} inspect --format='{{index .Config.Labels "'"${label_name}"'"}}' ${image_id}:${image_tag})"
         # shellcheck disable=SC2034
         __get_image_label="${image_label}"
     fi

--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -55,7 +55,7 @@ function validate_image() {
 # Arguments:
 # 1: image_path
 function generate_dockerfile() {
-    local image_path sed_param bob_var
+    local image_path sed_param bob_var build_timestamp
     image_path="$1"
     sed_param=()
     [[ ! -f "${image_path}"/Dockerfile.template ]] && die "Couldn't read ${image_path}/Dockerfile.template"
@@ -63,6 +63,7 @@ function generate_dockerfile() {
     for bob_var in ${!BOB_*}; do
         sed_param+=(-e "s|\${${bob_var}}|${!bob_var}|")
     done
+    build_timestamp=$(date '+%Y%m%d%H%M%S')
 
     # shellcheck disable=SC2016,SC2153,SC2154
     sed "${sed_param[@]}" \
@@ -71,6 +72,7 @@ function generate_dockerfile() {
         -e 's/${NAMESPACE}/'"${_current_namespace}"'/g' \
         -e 's/${TAG}/'"${IMAGE_TAG}"'/g' \
         -e 's/${MAINTAINER}/'"${AUTHOR}"'/g' \
+        -e '/^FROM .*/a LABEL kubler.build.timestamp '"${build_timestamp}" \
         "${image_path}/Dockerfile.template" > "${image_path}/Dockerfile" \
             || die "Error while generating ${image_path}/Dockerfile"
 }


### PR DESCRIPTION
Hi Erik,

At the moment if you have a dependency tree of images eg:

scratch -> bash -> app

and you modify and rebuild the "bash" image then invocations of kubler build do not automatically rebuild dependent images (in this case the "app").

This PR adds a kubler.build.timestamp label to the generated docker file and then uses that timestamp to determine whether to rebuild dependent images.

Let me know what you think.