### PR TITLE
Added optional emerge logging

### DIFF
--- a/template/docker/image/build.conf
+++ b/template/docker/image/build.conf
@@ -36,6 +36,10 @@ POST_BUILD_HC=true
 # Amount of health-check fails for a container before it considers itself unhealthy
 #POST_BUILD_HC_RETRY=3
 
+# Uncomment to have a build_logs directory created in your workspace containing all of the logs created by emerge
+# for the packages being installed.  Note: the value of the variable doesn't matter, just that it exists
+#BOB_EMERGE_LOGS=yes
+
 # Variables starting with BOB_ can be used for parameterization of Dockerfile.template and are also exported to
 # the build container, i.e. they may be referenced in your build.sh
 #BOB_FOO=bar


### PR DESCRIPTION
Sometimes a build will fail, but the logs disappear unless they are saved to the `_CONFIG` directory.  We can control this setting in the `build.conf` file by declaring a variable named `BOB_EMERGE_LOG=yes`, although the value of the variable doesn't matter, just that the variable exists.