### PR TITLE
Add add_patch() to build-root.sh.

### DIFF
--- a/engine/docker/bob-core/build-root.sh
+++ b/engine/docker/bob-core/build-root.sh
@@ -392,7 +392,7 @@ function add_patch() {
     patch_dir="/etc/portage/patches/${patch_package}"
     patch_file=$(cksum <<< "${patch_url}" | cut -f 1 -d ' ')
     # create dir if not existing
-    [ ! -d $patch_dir ] && mkdir -p ${patch_dir}
+    [ ! -d ${patch_dir} ] && mkdir -p ${patch_dir}
     curl -L "${patch_url}" --output "${patch_dir}/${patch_file}" || exit $?
 }
 

--- a/engine/docker/bob-core/build-root.sh
+++ b/engine/docker/bob-core/build-root.sh
@@ -379,6 +379,23 @@ function uninstall_package() {
     done
 }
 
+# Add a given patch for a given package to Portage
+# Usually called from configure_rootfs_build() hook.
+#
+# Arguments:
+# 1: package atom (i.e. app-shells/bash)
+# 2: patch url
+function add_patch() {
+    local patch_dir patch_package patch_url patch_file
+    patch_package=$1
+    patch_url=$2
+    patch_dir="/etc/portage/patches/${patch_package}"
+    patch_file=$(cksum <<< "${patch_url}" | cut -f 1 -d ' ')
+    # create dir if not existing
+    [ ! -d $patch_dir ] && mkdir -p ${patch_dir}
+    curl -L "${patch_url}" --output "${patch_dir}/${patch_file}" || exit $?
+}
+
 function configure_layman() {
     # no pesky prompts please
     sed -i'' 's/^check_official : Yes/check_official : No/g' /etc/layman/layman.cfg

--- a/engine/docker/bob-core/build-root.sh
+++ b/engine/docker/bob-core/build-root.sh
@@ -392,7 +392,7 @@ function add_patch() {
     patch_dir="/etc/portage/patches/${patch_package}"
     patch_file=$(cksum <<< "${patch_url}" | cut -f 1 -d ' ')
     # create dir if not existing
-    [ ! -d "${patch_dir}" ] && mkdir -p ${patch_dir}
+    [ ! -d "${patch_dir}" ] && mkdir -p "${patch_dir}"
     curl -L "${patch_url}" --output "${patch_dir}/${patch_file}" || exit $?
 }
 

--- a/engine/docker/bob-core/build-root.sh
+++ b/engine/docker/bob-core/build-root.sh
@@ -392,7 +392,7 @@ function add_patch() {
     patch_dir="/etc/portage/patches/${patch_package}"
     patch_file=$(cksum <<< "${patch_url}" | cut -f 1 -d ' ')
     # create dir if not existing
-    [ ! -d ${patch_dir} ] && mkdir -p ${patch_dir}
+    [ ! -d "${patch_dir}" ] && mkdir -p ${patch_dir}
     curl -L "${patch_url}" --output "${patch_dir}/${patch_file}" || exit $?
 }
 


### PR DESCRIPTION
Nodejs v12 is breaking with current icu and the only good way to solve this was using a patch i've found in Gentoo Bugtracker. So i thought it might be a good idea to add a function for it that would do it the "Portage Way".

It downloads the files to /etc/portage/patches and renames files to a more or less random checksum filename in order to avoid duplicated names, in case anyone would add more then one package. Gentoo Bugtracker for example does not have a good url structure to work with.