### PR TITLE
Dockerfile best practices

### DIFF
--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -72,9 +72,11 @@ function generate_dockerfile() {
         -e 's/${NAMESPACE}/'"${_current_namespace}"'/g' \
         -e 's/${TAG}/'"${IMAGE_TAG}"'/g' \
         -e 's/${MAINTAINER}/'"${AUTHOR}"'/g' \
-	-e 's/${build_timestamp}/'"${build_timestamp}"'/g' \
         "${image_path}/Dockerfile.template" > "${image_path}/Dockerfile" \
             || die "Error while generating ${image_path}/Dockerfile"
+
+    # insert build timestamp last to preserve build cache
+    echo "LABEL kubler.build.timestamp=${build_timestamp}" >> "${image_path}"/Dockerfile
 }
 
 # Returns given tag value from dockerfile or exit signal 3 if tag was not found.

--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -72,11 +72,9 @@ function generate_dockerfile() {
         -e 's/${NAMESPACE}/'"${_current_namespace}"'/g' \
         -e 's/${TAG}/'"${IMAGE_TAG}"'/g' \
         -e 's/${MAINTAINER}/'"${AUTHOR}"'/g' \
+	-e 's/${build_timestamp}/'"${build_timestamp}"'/g' \
         "${image_path}/Dockerfile.template" > "${image_path}/Dockerfile" \
             || die "Error while generating ${image_path}/Dockerfile"
-
-    # insert build timestamp last to preserve build cache
-    echo "LABEL kubler.build.timestamp ${build_timestamp}" >> "${image_path}"/Dockerfile
 }
 
 # Returns given tag value from dockerfile or exit signal 3 if tag was not found.
@@ -265,7 +263,7 @@ function build_image() {
 
         _status_msg="commit ${run_id} as image ${_current_namespace}/${builder_commit_id}:${IMAGE_TAG}"
         # shellcheck disable=SC2086
-        pwrap 'nolog' "${DOCKER}" commit ${DOCKER_COMMIT_OPTS} -c "LABEL kubler.build.timestamp $(date '+%Y%m%d%H%M%S')" \
+        pwrap 'nolog' "${DOCKER}" commit ${DOCKER_COMMIT_OPTS} -c "LABEL kubler.build.timestamp=$(date '+%Y%m%d%H%M%S')" \
             "${run_id}" "${_current_namespace}/${builder_commit_id}:${IMAGE_TAG}" \
             || die "${_status_msg}"
 

--- a/engine/docker/bob-core/Dockerfile.template
+++ b/engine/docker/bob-core/Dockerfile.template
@@ -1,5 +1,5 @@
 FROM ${BOB_CURRENT_STAGE3_ID}
-LABEL maintainer ${MAINTAINER}
+LABEL maintainer="${MAINTAINER}" kubler.build.timestamp="${build_timestamp}"
 
 RUN set -x && \
     echo 'GENTOO_MIRRORS="http://distfiles.gentoo.org/"' >> /etc/portage/make.conf && \

--- a/engine/docker/bob-core/Dockerfile.template
+++ b/engine/docker/bob-core/Dockerfile.template
@@ -1,5 +1,5 @@
 FROM ${BOB_CURRENT_STAGE3_ID}
-LABEL maintainer="${MAINTAINER}" kubler.build.timestamp="${build_timestamp}"
+LABEL maintainer="${MAINTAINER}"
 
 RUN set -x && \
     echo 'GENTOO_MIRRORS="http://distfiles.gentoo.org/"' >> /etc/portage/make.conf && \

--- a/engine/docker/bob-portage/Dockerfile.template
+++ b/engine/docker/bob-portage/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM busybox:latest
 
-LABEL maintainer="${MAINTAINER}" kubler.build.timestamp="${build_timestamp}"
+LABEL maintainer="${MAINTAINER}"
 
 COPY ${BOB_CURRENT_PORTAGE_FILE} /
 

--- a/engine/docker/bob-portage/Dockerfile.template
+++ b/engine/docker/bob-portage/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM busybox:latest
 
-LABEL maintainer ${MAINTAINER}
+LABEL maintainer="${MAINTAINER}" kubler.build.timestamp="${build_timestamp}"
 
 COPY ${BOB_CURRENT_PORTAGE_FILE} /
 

--- a/template/docker/builder/Dockerfile.template
+++ b/template/docker/builder/Dockerfile.template
@@ -1,4 +1,4 @@
 FROM ${NAMESPACE}/${_tmpl_image_name}
-LABEL maintainer="${MAINTAINER}" kubler.build.timestamp="${build_timestamp}"
+LABEL maintainer="${MAINTAINER}"
 
 CMD ["/bin/bash"]

--- a/template/docker/builder/Dockerfile.template
+++ b/template/docker/builder/Dockerfile.template
@@ -1,4 +1,4 @@
 FROM ${NAMESPACE}/${_tmpl_image_name}
-LABEL maintainer ${MAINTAINER}
+LABEL maintainer="${MAINTAINER}" kubler.build.timestamp="${build_timestamp}"
 
 CMD ["/bin/bash"]

--- a/template/docker/image/Dockerfile.template
+++ b/template/docker/image/Dockerfile.template
@@ -1,5 +1,5 @@
 FROM ${IMAGE_PARENT}
-LABEL maintainer="${MAINTAINER}" kubler.build.timestamp="${build_timstamp}"
+LABEL maintainer="${MAINTAINER}"
 
 ADD rootfs.tar /
 

--- a/template/docker/image/Dockerfile.template
+++ b/template/docker/image/Dockerfile.template
@@ -1,5 +1,5 @@
 FROM ${IMAGE_PARENT}
-LABEL maintainer ${MAINTAINER}
+LABEL maintainer="${MAINTAINER}" kubler.build.timestamp="${build_timstamp}"
 
 ADD rootfs.tar /
 


### PR DESCRIPTION
Hi,
This patch updates _kubler_ with [Dockerfile best pratices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#label) specially about the LABEL instruction and it also fixes an error in `podman commit` command.
All existing builders and images need to have its Dockerfile.template updated before a build :

```
find <kubler_namespace> -type f -name Dockerfile.template \
  -exec sed -e 's/^LABEL.*/LABEL\ maintainer=\"\${MAINTAINER}\"/g' -i {} \;
```