### PR TITLE
pipefail is a bashism, so use bash

### DIFF
--- a/template/docker/image/build-test.sh
+++ b/template/docker/image/build-test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eo pipefail
 #set -x
 

--- a/template/docker/image/build-test.sh
+++ b/template/docker/image/build-test.sh
@@ -1,9 +1,11 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+
+# Note: pipefail is not supported in POSIX shell and will be silently ignored, unless bash is used
 set -eo pipefail
 #set -x
 
 # Do some tests and exit with either 0 for success or 1 for error
-echo -e "Fix me or this built-test.sh will never succeed!"
+echo "Fix me or this built-test.sh will never succeed!"
 false || exit 1
 
 exit 0

--- a/template/docker/image/docker-healthcheck.sh
+++ b/template/docker/image/docker-healthcheck.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+
+# Note: pipefail is not supported in POSIX shell and will be silently ignored, unless bash is used
 set -eo pipefail
 
 # Do some tests and exit with either 0 for healthy or 1 for unhealthy

--- a/template/docker/image/docker-healthcheck.sh
+++ b/template/docker/image/docker-healthcheck.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 set -eo pipefail
 
 # Do some tests and exit with either 0 for healthy or 1 for unhealthy


### PR DESCRIPTION
docker image template build test shell scripts are using `set -o pipefail` which is a bashism, so set the shebang to use `bash`.