### PR TITLE
Add `BUILDER_SECCOMP` variable to `build.conf`

### DIFF
--- a/engine/docker.sh
+++ b/engine/docker.sh
@@ -552,6 +552,7 @@ function run_image() {
     [[ "${auto_rm}" == "true" ]] && docker_args+=("--rm")
     [[ -n "${container_name}" ]] && docker_args+=("--name" "${container_name//\//-}")
     [[ "${BUILDER_CAPS_SYS_PTRACE}" == "true" ]] && docker_args+=('--cap-add' 'SYS_PTRACE')
+    [[ -n "${BUILDER_SECCOMP}" ]] && docker_args+=("--security-opt" "seccomp=${BUILDER_SECCOMP}")
     [[ "${_container_mount_portage}" == "true" ]] && docker_args+=("--volumes-from" "${_PORTAGE_IMAGE//\//-}")
     # shellcheck disable=SC2154
     [[ ${#_container_args[@]} -gt 0 ]] && docker_args+=("${_container_args[@]}")

--- a/template/docker/builder/build.conf
+++ b/template/docker/builder/build.conf
@@ -10,6 +10,9 @@ STAGE3_DATE='20170101'
 # Run build container with `--cap-add SYS_PTRACE`, optional, default: false
 BUILDER_CAPS_SYS_PTRACE=true
 
+# Run build container with `--security-opt secomp="${BUILDER_SECCOMP}"`, optional
+#BUILDER_SECCOMP="${image_path}/seccomp.json"
+
 # Mount a host directory in the build container during the build, uses standard Docker -v syntax, default: unset/none
 # !! There is a reason Docker does not allow this, consider the consequences regarding build repeatability !!
 #BUILDER_MOUNTS=("${KUBLER_DATA_DIR}/tmp/somepath:/path/in/builder:ro")

--- a/template/docker/image/build.conf
+++ b/template/docker/image/build.conf
@@ -4,6 +4,9 @@
 # Run build container with `--cap-add SYS_PTRACE`, optional, default: false
 #BUILDER_CAPS_SYS_PTRACE='true'
 
+# Run build container with `--security-opt secomp="${BUILDER_SECCOMP}"`, optional
+#BUILDER_SECCOMP="${image_path}/seccomp.json"
+
 # Mount a host directory in the build container during the build, uses standard Docker -v syntax, default: unset/none
 # !! There is a reason Docker does not allow this, consider the consequences regarding build repeatability !!
 #BUILDER_MOUNTS=("${KUBLER_DATA_DIR}/tmp/somepath:/path/in/builder:ro")


### PR DESCRIPTION
Allows overriding the default seccomp profile the specified JSON file.