### PR TITLE
Autobuilds missing DIGEST.asc -- check .tar.xz.asc

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -397,10 +397,11 @@ function fetch_stage3_archive_name() {
 # 1: stage3_file
 function download_stage3() {
     [[ -d "${KUBLER_DOWNLOAD_DIR}" ]] || mkdir -p "${KUBLER_DOWNLOAD_DIR}"
-    local is_autobuild stage3_file stage3_contents stage3_digests sha512_hashes sha512_check sha512_failed \
+    local is_autobuild stage3_file stage3_asc stage3_contents stage3_digests sha512_hashes sha512_check sha512_failed \
           wget_exit wget_args
     is_autobuild=false
     stage3_file="$1"
+    stage3_asc="${stage3_file}.asc"
     stage3_contents="${stage3_file}.CONTENTS"
     # some stage3 builds use a compressed contents file now while others still use the plain variant
     if ! wget -q --method=HEAD "${ARCH_URL}${stage3_contents}"; then
@@ -408,14 +409,14 @@ function download_stage3() {
     fi
     stage3_digests="${stage3_file}.DIGESTS"
     if [[ "${ARCH_URL}" == *autobuilds*  ]]; then
-        stage3_digests="${stage3_file}.DIGESTS.asc"
+        #stage3_digests="${stage3_file}.DIGESTS.asc"
         is_autobuild=true
     fi
 
     wget_args=()
     [[ "${_arg_verbose}" == 'off' ]] && wget_args+=( '-q' '-nv' )
 
-    for file in "${stage3_file}" "${stage3_contents}" "${stage3_digests}"; do
+    for file in "${stage3_file}" "${stage3_asc}" "${stage3_contents}" "${stage3_digests}"; do
         [ -f "${KUBLER_DOWNLOAD_DIR}/${file}" ] && continue
 
         _handle_download_error_args="${KUBLER_DOWNLOAD_DIR}/${file}"
@@ -428,7 +429,7 @@ function download_stage3() {
     done
     # shellcheck disable=SC2154
     if [ "${_arg_skip_gpg_check}" = false ] && [ "${is_autobuild}" = true ]; then
-        gpg --verify "${KUBLER_DOWNLOAD_DIR}/${stage3_digests}" || die "Insecure digests"
+        gpg --verify "${KUBLER_DOWNLOAD_DIR}/${stage3_asc}" || die "Signature check failed"
     elif [ "${is_autobuild}" = false ]; then
         msg "GPG verification not supported for experimental stage3 tar balls, only checking SHA512"
     fi


### PR DESCRIPTION
# The Problem
Latest distribution of Gentoo stage3 doesn't seem to have the clearsigned `.DIGESTS.asc` files anymore.
I couldn't find any news on this nor the code in release engineering or catalyst etc that builds these files.

The missing `.DIGEST.asc` causes this error:

```
»[✔]»[init]» done.
»[⠼]»[kubler/bob-musl-core]» download stage3-amd64-musl-hardened-20220214T095322Z.tar.xz [ 170M ]

»[✘]»[kubler/bob-musl-core]» caught interrupt, aborting..
»[✘]»[kubler/bob-musl-core]» fatal: Aborted download of /home/berne/.kubler/downloads/stage3-amd64-musl-hardened-20220214T095322Z.tar.xz.DIGESTS.asc
```

And in `~/.kubler/log/build.log`

```
»»» Tue Feb 15 13:22:01 AEDT 2022 »»» exec: docker tag kubler-gentoo/portage:20220214 kubler-gentoo/portage:latest
»»» Tue Feb 15 13:22:01 AEDT 2022 »»» exec: docker run --name kubler-gentoo-portage kubler-gentoo/portage true
»»» Tue Feb 15 13:22:25 AEDT 2022 »»» exec: download_stage3 stage3-amd64-musl-hardened-20220214T095322Z.tar.xz
»[✘]»[kubler/bob-musl-core]» HTTP 404 for stage3-amd64-musl-hardened-20220214T095322Z.tar.xz.DIGESTS.asc, try running the update command to resolve this.
```

# The Solution (this PR)

The distribution's `.tar.xz` have signature `.tar.xz.asc` files.

The PR will download the `.tar.xz.asc` and check it instead.

The DIGEST is still used to check hashes which is redundant but doesn't hurt security.

# A Warning

I'm not that familiar with this bit of the code or using other (experimental) stage3s, so I'm not sure what impact, if any, these changes will have.