### PR TITLE
Fix dl_name with latest

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -463,7 +463,7 @@ function download_portage_snapshot() {
     for file in "${portage_file}" "${portage_sig}" "${portage_md5}"; do
         dl_name="${file}"
         if [[ "${PORTAGE_DATE}" == 'latest' ]]; then
-            dl_name="${portage_file//latest/${_TODAY}}"
+            dl_name="${file//latest/${_TODAY}}"
         fi
         if [[ ! -f "${KUBLER_DOWNLOAD_DIR}/${dl_name}" ]]; then
             wget_args=()


### PR DESCRIPTION
Function `download_portage_snapshot()` has a subtle bug when `$PORTAGE_DATE` equals `latest` (the default), it sets `dl_name` to be `$_TODAY`.  It should do this for every file, but it always sets dl_name to portage_file, so each loop dl_name will be the same, and the "already download" check will pass, skipping the other loops, and the final check at the end.

With this fix, `dl_name` is set correctly based off `file`, similar to the line 464. This causes all 3 files to be downloaded, and the final check at the end to not be skipped.