### PR TITLE
Fix stage3 GPG signature verification

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -428,10 +428,12 @@ function download_stage3() {
         rm_trap_fn 'handle_download_error'
     done
     # shellcheck disable=SC2154
-    if [ "${_arg_skip_gpg_check}" = false ] && [ "${is_autobuild}" = true ]; then
+    if [ "${_arg_skip_gpg_check}" != 'on' ] && [ "${is_autobuild}" = true ]; then
         gpg --verify "${KUBLER_DOWNLOAD_DIR}/${stage3_asc}" || die "Signature check failed"
     elif [ "${is_autobuild}" = false ]; then
         msg "GPG verification not supported for experimental stage3 tar balls, only checking SHA512"
+    else
+	msg "Skipped stage3 GPG signature check"
     fi
     # some experimental stage3 builds don't update the file names in the digest file, replace so sha512 check won't fail
     grep -q "${STAGE3_BASE}-2008\.0\.tar\.bz2" "${KUBLER_DOWNLOAD_DIR}/${stage3_digests}" \
@@ -485,6 +487,8 @@ function download_portage_snapshot() {
 
     if [[ "${_arg_skip_gpg_check}" != 'on' ]] && [[ -f "${KUBLER_DOWNLOAD_DIR}/${portage_sig}" ]]; then
         gpg --verify "${KUBLER_DOWNLOAD_DIR}/${portage_sig}" "${KUBLER_DOWNLOAD_DIR}/${portage_file}" || die "Insecure digests."
+    else
+	msg "Skipped Portage GPG signature check"
     fi
 }
 


### PR DESCRIPTION
Typically, the value of `_arg_skip_gpg_check` will be `off` not `false`. Hence this if condition will fail and the gpg verification will be skipped. I've made the check the same as for portage (`!= 'on'`), and I've also added a catch all `else` condition to print a message, so that it should be obvious when signature checks are skipped.