### PR TITLE
OpenSSL USE bindist dropped

### DIFF
--- a/template/docker/builder/build_stage3.sh
+++ b/template/docker/builder/build_stage3.sh
@@ -23,10 +23,6 @@ configure_builder() {
     # install default packages
     # when using overlay1 docker storage the created hard link will trigger an error during openssh uninstall
     [[ -f /usr/"${_LIB}"/misc/ssh-keysign ]] && rm /usr/"${_LIB}"/misc/ssh-keysign
-    emerge -C net-misc/openssh
-    update_use 'net-misc/openssh' -bindist
-    update_use 'dev-libs/openssl' -bindist
-    emerge dev-libs/openssl
     update_use 'dev-vcs/git' '-perl'
     update_use 'app-crypt/pinentry' '+ncurses'
     update_keywords 'dev-python/ssl-fetch' '+~amd64'


### PR DESCRIPTION
- Gentoo dropped USE bindist from openssl https://www.gentoo.org/support/news-items/2021-10-17-openssl-bindist-removal.html
- So, no need to remove openssh, set `-bindist` USE flag, and re-emerge, as there is no such USE flag, and the re-emerging is unneccesary.

Basically same thing as https://github.com/edannenberg/kubler-images/pull/8