### PR TITLE
Update update_use function to work with new flaggie

### DIFF
--- a/engine/docker/bob-core/build-root.sh
+++ b/engine/docker/bob-core/build-root.sh
@@ -293,7 +293,7 @@ function log_as_installed() {
 # reset all use flags: update_use app-shells/bash %
 function update_use() {
     # shellcheck disable=SC2068
-    flaggie ${@}
+    flaggie --no-diff ${@}
 }
 
 # Just for better readability of build.sh

--- a/engine/docker/bob-core/build-root.sh
+++ b/engine/docker/bob-core/build-root.sh
@@ -42,7 +42,6 @@ _emerge_bin="${BOB_EMERGE_BIN:-emerge}"
 _emerge_opt="${BOB_EMERGE_OPT:-}"
 
 BOB_KEEP_BUILD_LOG="${BOB_KEEP_BUILD_LOG:-false}"
-BOB_PACKAGE_CONFIG_STRICT="${BOB_PACKAGE_CONFIG_STRICT:-true}"
 BOB_UPDATE_WORLD="${BOB_UPDATE_WORLD:-false}"
 
 # Arguments:
@@ -282,7 +281,7 @@ function log_as_installed() {
     echo "*${1}*: ${2} | ${3}" >> "${_DOC_PACKAGE_INSTALLED}"
 }
 
-# Thin wrapper for app-portage/flaggie, a tool for managing portage keywords and use flags
+# Thin wrapper for modern (2023, 0.99.x) app-portage/flaggie, a tool for managing portage keywords and use flags
 #
 # Examples:
 #
@@ -293,11 +292,8 @@ function log_as_installed() {
 # reset use/keyword to default: update_use app-shells/bash %readline %ncurses %~amd64
 # reset all use flags: update_use app-shells/bash %
 function update_use() {
-    local strict_mode
-    strict_mode='--strict'
-    [[ "${BOB_PACKAGE_CONFIG_STRICT}" != true ]] && strict_mode='--quiet'
     # shellcheck disable=SC2068
-    flaggie "${strict_mode}" --destructive-cleanup ${@}
+    flaggie ${@}
 }
 
 # Just for better readability of build.sh

--- a/kubler.conf
+++ b/kubler.conf
@@ -65,8 +65,6 @@ BOB_EMERGE_DEFAULT_OPTS="${BOB_EMERGE_DEFAULT_OPTS:--b -k --binpkg-respect-use=y
 # When enabled emerge build logs of the last run are kept at <image_dir>/log
 #BOB_KEEP_BUILD_LOG=false
 
-# When enabled `update_use/keywords` helpers fail the build if, for example, a use flag doesn't exist
-#BOB_PACKAGE_CONFIG_STRICT=true
 # When enabled the default builders will run `emerge -vuD --newuse world` once on creation. Less potential for errors
 # at the cost of increased build time
 #BOB_UPDATE_WORLD=false


### PR DESCRIPTION
- New app-portage/flaggie has different command line arguments. No longer has a `--strict` or `--quiet` mode.
- Function is now just passes through to flaggie, so it's just an alias (name change), but preserves behaviour for `build.sh` scripts, etc.
- Removed `BOB_PACKAGE_CONFIG_STRICT` as it no longer serves any purpose.
- Related to https://github.com/edannenberg/kubler/issues/220 and https://github.com/edannenberg/kubler/pull/221.