### PR TITLE
Optimize Dockerfile for bob-portage

### DIFF
--- a/engine/docker/bob-portage/Dockerfile.template
+++ b/engine/docker/bob-portage/Dockerfile.template
@@ -1,10 +1,11 @@
-FROM busybox:latest
+FROM busybox:latest AS builder
 
 LABEL maintainer="${MAINTAINER}"
 
 COPY ${BOB_CURRENT_PORTAGE_FILE} /
 COPY patches/ /patches
 
+# We don't really need to delete the tarball
 RUN set -x && \
     mkdir -p /var/db/repos/ && \
     xzcat /${BOB_CURRENT_PORTAGE_FILE} | tar -xf - -C /var/db/repos && \
@@ -16,4 +17,8 @@ RUN set -x && \
     patch -p1 -i /patches/0003* && \
     patch -p1 -i /patches/0004*
 
+FROM busybox:latest
+COPY --from=builder /var/db/repos/gentoo /var/db/repos/gentoo
+
+LABEL maintainer="${MAINTAINER}"
 VOLUME /var/db/repos /var/cache/eix


### PR DESCRIPTION
- The original Dockerfile would create unnecessary layers, the copy of the portage tarball would be in a layer, a subsequent layer extracts and deletes it, but due to layers it is still consuming space in the resulting image.
- After this change, multi-stage builds are used to ensure the resulting image is lean, it does not have extraneous layers with the tarball.