### PR TITLE
Update STAGE3_BASE

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -55,7 +55,7 @@ BOB_HOST_UID=$(id -u)
 BOB_HOST_GID=$(id -g)
 
 # stage3 defaults, override via build container .conf
-STAGE3_BASE="stage3-amd64-hardened+nomultilib"
+STAGE3_BASE="stage3-amd64-hardened-nomultilib-openrc"
 
 _kubler_trap_functions=()
 _kubler_internal_abort=
@@ -387,7 +387,7 @@ function fetch_stage3_archive_name() {
             is_newer_stage3_date "${remote_date}" "${BASH_REMATCH[$((max_cap-3))]}${BASH_REMATCH[$((max_cap-2))]}" \
                 && { remote_date="${BASH_REMATCH[$((max_cap-3))]}${BASH_REMATCH[$((max_cap-2))]}";
                      remote_file_type="${BASH_REMATCH[$((max_cap-1))]}"; }
-	    break
+            break
         fi
     done
     [[ "${remote_date//[!0-9]/}" -eq 0 ]] && return 3

--- a/template/docker/builder/build.conf
+++ b/template/docker/builder/build.conf
@@ -2,7 +2,7 @@
 BUILDER="${_tmpl_builder}"
 
 # ..or bootstrap from a fresh stage3, overrides BUILDER if STAGE3_BASE is defined
-STAGE3_BASE='stage3-amd64-hardened+nomultilib'
+STAGE3_BASE='stage3-amd64-hardened-nomultilib-openrc'
 STAGE3_DATE='20170101'
 #ARCH='amd64'
 #ARCH_URL="${MIRROR}releases/${ARCH}/autobuilds/current-${STAGE3_BASE}/"


### PR DESCRIPTION
- Glibc stage3 base name changed a fair while ago with openrc/systemd split. The values are overridden by the build.conf in builders, e.g. edannenberg/kubler-images.
- Also snuck in a fixed a stray tab

This matters to me because I've added a custom command that cares.