### PR TITLE
Quote update_use and update_keywords args

### DIFF
--- a/engine/docker/bob-core/build-root.sh
+++ b/engine/docker/bob-core/build-root.sh
@@ -309,14 +309,12 @@ function update_use() {
     flaggie_args=()
     [[ "${BOB_PACKAGE_CONFIG_DIFF}" == 'false' ]] && flaggie_args+=('--no-diff')
     [[ "${BOB_PACKAGE_CONFIG_STRICT}" == 'false' ]] && flaggie_args+=('--force')
-    # shellcheck disable=SC2068
-    flaggie "${flaggie_args[@]}" ${@}
+    flaggie "${flaggie_args[@]}" "${@}"
 }
 
 # Just for better readability of build.sh
 function update_keywords() {
-    # shellcheck disable=SC2068
-    update_use ${@}
+    update_use "${@}"
 }
 
 function mask_package() {


### PR DESCRIPTION
`${@}` still needs to be quoted to prevent globbing