### PR TITLE
app-portage/eix now hooks postsync.d

### DIFF
--- a/engine/docker/bob-core/build-root.sh
+++ b/engine/docker/bob-core/build-root.sh
@@ -109,15 +109,6 @@ function install_git_postsync_hooks() {
     chmod -x /etc/portage/repo.postsync.d/sync_gentoo_cache
 }
 
-# Setup eix and init db
-function configure_eix() {
-    eix-update
-    # configure post-sync
-    mkdir -p /etc/portage/postsync.d/
-    ln -s /usr/bin/eix-postsync /etc/portage/postsync.d/50-eix-postsync
-    ln -s /usr/bin/eix-diff /etc/portage/postsync.d/51-eix-diff
-}
-
 # Extract saved resources, like headers, from a parent image.
 #
 # Arguments:

--- a/engine/docker/bob-core/etc/portage/postsync.d/eix
+++ b/engine/docker/bob-core/etc/portage/postsync.d/eix
@@ -1,8 +1,0 @@
-#!/bin/sh
-if [[ -e /var/cache/eix/portage.eix ]]; then
-    cp -a /var/cache/eix/portage.eix /var/cache/eix/previous.eix;
-fi
-eix-update
-if [[ -e /var/cache/eix/previous.eix ]]; then
-    eix-diff;
-fi

--- a/template/docker/builder/build_stage3.sh
+++ b/template/docker/builder/build_stage3.sh
@@ -11,7 +11,7 @@ configure_builder() {
     # install basics used by helper functions
     eselect news read new 1> /dev/null
     emerge app-portage/flaggie app-portage/eix app-portage/gentoolkit
-    configure_eix
+    eix-update
     mkdir -p /etc/portage/package.{accept_keywords,unmask,mask,use}
     touch /etc/portage/package.accept_keywords/flaggie
     # set locale of build container


### PR DESCRIPTION
- Since app-portage/eix 0.36.7-r2 it now installs eix-postsync as a symlink in portage's postsync via /etc/portage/postsync.d/.
- eix-postsync does what engine/docker/bob-core/etc/portage/postsync.d/eix did, so it is no longer needed.
- Removed `configure_eix()` function as it is no longer needed.
- Run `eix-update` executable directly rather than calling `configure_eix` function.

Before this change `kubler build figlet` would fail with:

```
 * Messages for package app-portage/flaggie-0.99.8:

 * This is a preview release of flaggie 1.x. It it not fully featured
 * yet and it may have significant bugs. Please back your /etc/portage
 * up before using it. Verify the results using --pretend.
>>> Auto-cleaning packages...

>>> No outdated packages were found on your system.
Reading Portage settings...
Building database (/var/cache/eix/portage.eix)...
[0] "gentoo" /var/db/repos/gentoo/ (cache: metadata-md5-or-flat)
     Reading category 172|172 (100) Finished
Applying masks...
Calculating hash tables...
Writing database file /var/cache/eix/portage.eix...
Database contains 19076 packages in 172 categories
ln: failed to create symbolic link '/etc/portage/postsync.d/50-eix-postsync': File exists
```

`/etc/portage/postsync.d/50-eix-postsync` exists, and was installed by `app-portage/eix`. Because upstream eix package does the hooking now, it is no longer necessary for Kubler to install hooks.