### PR TITLE
Update user-info.eclass and acct-user.eclass patches

### DIFF
--- a/engine/docker/bob-portage/patches/0002-Revert-user-info.eclass-Fixing-user-group-creation-w.patch
+++ b/engine/docker/bob-portage/patches/0002-Revert-user-info.eclass-Fixing-user-group-creation-w.patch
@@ -58,17 +58,22 @@ index 5550e4f08ee..3838585ab6c 100644
  		;;
  	esac
  }
-@@ -165,16 +151,7 @@ egetgroups() {
+@@ -165,21 +151,7 @@ egetgroups() {
  	[[ $# -eq 1 ]] || die "usage: egetgroups <user>"
  
  	local egroups_arr
--	if [[ -n "${ROOT}" ]]; then
--		local pgroup=$(egetent passwd "$1" | cut -d: -f1)
--		local sgroups=( $(grep -E ":([^:]*,)?$1(,[^:]*)?$" "${ROOT}/etc/group" | cut -d: -f1) )
 -
--		# Remove primary group from list
--		sgroups=${sgroups#${pgroup}}
--		egroups_arr=( ${pgroup} ${sgroups[@]} )
+-	if [[ -n "${ROOT}" ]]; then
+-		local pgid=$(egetent passwd "$1" | cut -d: -f4)
+-		local pgroup=$(egetent group "${pgid}" | cut -d: -f1)
+-		local sgroups=( $(grep -E ":([^:]*,)?$1(,[^:]*)?$" "${ROOT}/etc/group" | cut -d: -f1) )
+-		egroups_arr=( "${pgroup}" )
+-		local sg
+-		for sg in "${sgroups[@]}"; do
+-			if [[ ${sg} != ${pgroup} ]]; then
+-				egroups_arr+=( "${sg}" )
+-			fi
+-		done
 -	else
 -		read -r -a egroups_arr < <(id -G -n "$1")
 -	fi

--- a/engine/docker/bob-portage/patches/0003-Revert-acct-user.eclass-Fixing-user-group-creation-w.patch
+++ b/engine/docker/bob-portage/patches/0003-Revert-acct-user.eclass-Fixing-user-group-creation-w.patch
@@ -40,21 +40,35 @@ index 66a4d6667888..fc631336859c 100644
  		elog "Adding user ${ACCT_USER_NAME}"
  		useradd "${opts[@]}" "${ACCT_USER_NAME}" || die "useradd failed with status $?"
  		_ACCT_USER_ADDED=1
-@@ -369,13 +358,7 @@ acct-user_pkg_preinst() {
- 	if [[ ${_ACCT_USER_HOME} != /dev/null ]]; then
+@@ -373,27 +373,7 @@ acct-user_pkg_preinst() {
  		# default ownership to user:group
- 		if [[ -z ${_ACCT_USER_HOME_OWNER} ]]; then
--			if [[ -n ${ROOT} ]]; then
--				local euid=$(egetent passwd ${ACCT_USER_NAME} | cut -d: -f3)
--				local egid=$(egetent passwd ${ACCT_USER_NAME} | cut -d: -f4)
--				_ACCT_USER_HOME_OWNER=${euid}:${egid}
--			else
--				_ACCT_USER_HOME_OWNER=${ACCT_USER_NAME}:${groups[0]}
+ 		local user=${ACCT_USER_NAME}
+ 		local group=${groups[0]}
+-		if [[ -n ${ROOT} ]]; then
+-			# resolve user:group to uid:gid
+-			if [[ ${_ACCT_USER_HOME_OWNER} == *:* ]]; then
+-				user=${_ACCT_USER_HOME_OWNER%:*}
+-				group=${_ACCT_USER_HOME_OWNER#*:}
+-			elif [[ -n ${_ACCT_USER_HOME_OWNER} ]]; then
+-				user=${_ACCT_USER_HOME_OWNER}
+-				group=
 -			fi
-+			_ACCT_USER_HOME_OWNER=${ACCT_USER_NAME}:${groups[0]}
+-			local euid= egid=
+-			if [[ -n ${user} ]]; then
+-				euid=$(egetent passwd "${user}" | cut -d: -f3)
+-				if [[ -z ${group} ]]; then
+-					egid=$(egetent passwd "${user}" | cut -d: -f4)
+-				fi
+-			fi
+-			if [[ -n ${group} ]]; then
+-				egid=$(egetent group "${group}" | cut -d: -f3)
+-			fi
+-			_ACCT_USER_HOME_OWNER=${euid}:${egid}
+-		elif [[ -z ${_ACCT_USER_HOME_OWNER} ]]; then
++		if [[ -z ${_ACCT_USER_HOME_OWNER} ]]; then
+ 			_ACCT_USER_HOME_OWNER=${user}:${group}
  		fi
  		# Path might be missing due to INSTALL_MASK, etc.
- 		# https://bugs.gentoo.org/691478
 @@ -427,10 +410,6 @@ acct-user_pkg_postinst() {
  		opts+=( --expiredate "" --unlock )
  	fi


### PR DESCRIPTION
Gentoo has updated `user-info.eclass` and `acct-user.eclass` recently:

https://github.com/gentoo/gentoo/commit/9acc90f195babd6be689ea30a5b6dbdb42ba55a1
https://github.com/gentoo/gentoo/commit/0f5b1abe6af8e4158491d11370748edc9a004223
https://github.com/gentoo/gentoo/commit/8232c3efbc7befa22763043a0bfd5a0b894db342

This broke kubler's patches to those eclasses.

This pull request fixes the patches.

Note: I don't know why those patches were needed in the first place. I'm just reverting upstream changes.